### PR TITLE
feat: eth_getUserOperationReceipt to report whether in mempool

### DIFF
--- a/internal/start/private.go
+++ b/internal/start/private.go
@@ -39,7 +39,8 @@ func PrivateMode() {
 
 	logr := logger.NewZeroLogr().
 		WithName("stackup_bundler").
-		WithValues("bundler_mode", "private")
+		WithValues("bundler_mode", "private").
+		V(1)
 
 	eoa, err := signer.New(conf.PrivateKey)
 	if err != nil {

--- a/internal/start/searcher.go
+++ b/internal/start/searcher.go
@@ -40,7 +40,8 @@ func SearcherMode() {
 
 	logr := logger.NewZeroLogr().
 		WithName("stackup_bundler").
-		WithValues("bundler_mode", "searcher")
+		WithValues("bundler_mode", "searcher").
+		V(1)
 
 	eoa, err := signer.New(conf.PrivateKey)
 	if err != nil {

--- a/pkg/mempool/instance.go
+++ b/pkg/mempool/instance.go
@@ -27,6 +27,24 @@ func New(db *badger.DB) (*Mempool, error) {
 	return &Mempool{db, queue}, nil
 }
 
+// HasUserOpHash returns true if the UserOperation with the given userOpHash is
+// in the mempool.
+func (m *Mempool) HasUserOpHash(userOpHash string) (bool, error) {
+	err := m.db.View(func(txn *badger.Txn) error {
+		_, err := txn.Get([]byte(userOpHash))
+		return err
+	})
+
+	if err == badger.ErrKeyNotFound {
+
+		return false, nil
+	} else if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
 // GetOps returns all the UserOperations associated with an EntryPoint and Sender address.
 func (m *Mempool) GetOps(entryPoint common.Address, sender common.Address) ([]*userop.UserOperation, error) {
 	ops := m.queue.GetOps(entryPoint, sender)

--- a/pkg/modules/solution/solveintents.go
+++ b/pkg/modules/solution/solveintents.go
@@ -99,6 +99,11 @@ func (ei *IntentsHandler) SolveIntents() modules.BatchHandlerFunc {
 		// to be sent to the Solver
 		modelUserOps := *(*[]*model.UserOperation)(unsafe.Pointer(&ctx.Batch))
 
+		println("Received batch of UserOperations for solution: ", len(modelUserOps))
+		for idx, op := range modelUserOps {
+			println("Received UserOperation: [", idx, "], isIntent", op.HasIntent(), "op:", op.String())
+		}
+
 		// Prepare the body to send to the Solver
 		body := ei.bufferIntentOps(ctx.EntryPoint, ctx.ChainID, batchIntentIndices, modelUserOps)
 


### PR DESCRIPTION
-1 Nonce --> In mempool, e.g.
``` bash
curl -Ss --request POST \
   --url http://localhost:4337 \
   --header 'accept: application/json' \
   --header 'content-type: application/json' \
   --data '{
    "jsonrpc": "2.0",
    "id": 1,
    "method": "eth_getUserOperationReceipt",
    "params": ["0xc6b41d38ab8aff882624d4c72e8564d3f08d7d9dd401b4b355cf2561cc76123b"]
   }'
```
```json
{
   "id":1,
   "jsonrpc":"2.0",
   "result":{
      "userOpHash":"0x0000000000000000000000000000000000000000000000000000000000000000",
      "sender":"0x0000000000000000000000000000000000000000",
      "paymaster":"0x0000000000000000000000000000000000000000",
      "nonce":"-1",
      "success":false,
      "actualGasCost":"",
      "actualGasUsed":"",
      "from":"0x0000000000000000000000000000000000000000",
      "receipt":null,
      "logs":null
   }
}
```